### PR TITLE
Add more test coverage, prefer returning nil when input is nil

### DIFF
--- a/app/action.go
+++ b/app/action.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 
 	appv1 "github.com/tempestdx/protobuf/gen/go/tempestdx/app/v1"
 )
@@ -18,6 +19,24 @@ func (a *App) getActionDefinition(resource, action string) (*ActionDefinition, b
 		}
 	}
 	return nil, false
+}
+
+func (rd *ResourceDefinition) AddActionDefinition(ad ActionDefinition) {
+	for _, existing := range rd.actions {
+		if existing.Name == ad.Name {
+			panic(fmt.Sprintf("ActionDefinition with the same name '%s' already exists", ad.Name))
+		}
+	}
+
+	if ad.InputSchema == nil {
+		ad.InputSchema = MustParseJSONSchema(GenericEmptySchema)
+	}
+
+	if ad.OutputSchema == nil {
+		ad.OutputSchema = MustParseJSONSchema(GenericEmptySchema)
+	}
+
+	rd.actions = append(rd.actions, ad)
 }
 
 type ActionDefinition struct {

--- a/app/link.go
+++ b/app/link.go
@@ -22,7 +22,7 @@ type Link struct {
 
 func (l *Link) toProto() *appv1.Link {
 	if l == nil {
-		return &appv1.Link{}
+		return nil
 	}
 
 	return &appv1.Link{
@@ -34,7 +34,7 @@ func (l *Link) toProto() *appv1.Link {
 
 func linkFromProto(l *appv1.Link) *Link {
 	if l == nil {
-		return &Link{}
+		return nil
 	}
 
 	return &Link{

--- a/app/link_test.go
+++ b/app/link_test.go
@@ -29,7 +29,7 @@ func TestLinkToProto(t *testing.T) {
 		{
 			desc:   "OK - nil",
 			link:   nil,
-			linkpb: &appv1.Link{},
+			linkpb: nil,
 		},
 	}
 	for _, tc := range testCases {
@@ -61,7 +61,7 @@ func TestLinkFromProto(t *testing.T) {
 		{
 			desc:   "OK - nil",
 			linkpb: nil,
-			link:   &Link{},
+			link:   nil,
 		},
 	}
 	for _, tc := range testCases {

--- a/app/list.go
+++ b/app/list.go
@@ -18,6 +18,10 @@ type ListRequest struct {
 }
 
 func listRequestFromProto(r *appv1.ListResourcesRequest) *ListRequest {
+	if r == nil {
+		return nil
+	}
+
 	return &ListRequest{
 		Metadata: metadataFromProto(r.Metadata),
 		Resource: resourceFromProto(r.Resource),
@@ -33,8 +37,8 @@ type ListResponse struct {
 }
 
 type listOperation struct {
-	schema  schema
-	handler ListFunc
+	schema schema
+	fn     ListFunc
 }
 
 type ListFunc func(context.Context, *ListRequest) (*ListResponse, error)

--- a/app/list_test.go
+++ b/app/list_test.go
@@ -1,0 +1,49 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appv1 "github.com/tempestdx/protobuf/gen/go/tempestdx/app/v1"
+)
+
+func TestListRequestFromProto(t *testing.T) {
+	testCases := []struct {
+		desc      string
+		listReq   *ListRequest
+		listReqpb *appv1.ListResourcesRequest
+	}{
+		{
+			desc: "OK",
+			listReq: &ListRequest{
+				Resource: &Resource{
+					ExternalID:  "external-id",
+					DisplayName: "display-name",
+					Type:        "type",
+					Links:       []*Link{},
+					Properties:  map[string]any{},
+				},
+				Next: "1",
+			},
+			listReqpb: &appv1.ListResourcesRequest{
+				Resource: &appv1.Resource{
+					ExternalId:  "external-id",
+					DisplayName: "display-name",
+					Type:        "type",
+				},
+				Metadata: nil,
+				Next:     "1",
+			},
+		},
+		{
+			desc:      "OK - nil",
+			listReq:   nil,
+			listReqpb: nil,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			assert.Equal(t, tc.listReq, listRequestFromProto(tc.listReqpb))
+		})
+	}
+}

--- a/app/metadata.go
+++ b/app/metadata.go
@@ -17,7 +17,7 @@ type Metadata struct {
 
 func metadataFromProto(m *appv1.Metadata) *Metadata {
 	if m == nil {
-		return &Metadata{}
+		return nil
 	}
 
 	owners := make([]Owner, 0, len(m.Owners))

--- a/app/metadata_test.go
+++ b/app/metadata_test.go
@@ -108,7 +108,7 @@ func TestMetadataFromProto(t *testing.T) {
 		},
 		{
 			desc: "OK - nil",
-			md:   &Metadata{},
+			md:   nil,
 			mdpb: nil,
 		},
 	}

--- a/app/operation.go
+++ b/app/operation.go
@@ -21,10 +21,7 @@ type OperationRequest struct {
 
 func operationRequestFromProto(r *appv1.ExecuteResourceOperationRequest) *OperationRequest {
 	if r == nil {
-		return &OperationRequest{
-			Metadata: &Metadata{},
-			Resource: &Resource{},
-		}
+		return nil
 	}
 
 	return &OperationRequest{

--- a/app/operation_test.go
+++ b/app/operation_test.go
@@ -17,7 +17,6 @@ func TestOperationRequestFromProto(t *testing.T) {
 		{
 			desc: "OK",
 			opReq: &OperationRequest{
-				Metadata: &Metadata{},
 				Resource: &Resource{
 					ExternalID:  "external-id",
 					DisplayName: "display-name",
@@ -41,11 +40,8 @@ func TestOperationRequestFromProto(t *testing.T) {
 			},
 		},
 		{
-			desc: "OK - nil",
-			opReq: &OperationRequest{
-				Metadata: &Metadata{},
-				Resource: &Resource{},
-			},
+			desc:    "OK - nil",
+			opReq:   nil,
 			opReqpb: nil,
 		},
 	}

--- a/app/resource.go
+++ b/app/resource.go
@@ -23,7 +23,7 @@ type Resource struct {
 
 func (r *Resource) toProto() (*appv1.Resource, error) {
 	if r == nil {
-		return &appv1.Resource{}, nil
+		return nil, fmt.Errorf("resource is nil")
 	}
 
 	links := make([]*appv1.Link, 0, len(r.Links))
@@ -47,7 +47,7 @@ func (r *Resource) toProto() (*appv1.Resource, error) {
 
 func resourceFromProto(r *appv1.Resource) *Resource {
 	if r == nil {
-		return &Resource{}
+		return nil
 	}
 
 	links := make([]*Link, 0, len(r.Links))

--- a/app/resource_definition_test.go
+++ b/app/resource_definition_test.go
@@ -1,1 +1,416 @@
 package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetResourceDefinition(t *testing.T) {
+	testCases := []struct {
+		desc                       string
+		app                        *App
+		resourceType               string
+		expectedResourceDefinition *ResourceDefinition
+		found                      bool
+	}{
+		{
+			desc: "OK - Found",
+			app: &App{
+				resourceDefinitions: []ResourceDefinition{
+					{
+						Type: "example",
+					},
+				},
+			},
+			resourceType: "example",
+			expectedResourceDefinition: &ResourceDefinition{
+				Type: "example",
+			},
+			found: true,
+		},
+		{
+			desc: "OK - Not Found",
+			app: &App{
+				resourceDefinitions: []ResourceDefinition{
+					{
+						Type: "example",
+					},
+				},
+			},
+			resourceType: "example2",
+			found:        false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			resourceDefinition, ok := tc.app.getResourceDefinition(tc.resourceType)
+			if !tc.found {
+				assert.Nil(t, resourceDefinition)
+				assert.False(t, ok)
+				return
+			}
+
+			assert.True(t, ok)
+			assert.Equal(t, tc.expectedResourceDefinition, resourceDefinition)
+		})
+	}
+}
+
+var simpleOpFn = func(_ context.Context, _ *OperationRequest) (*OperationResponse, error) {
+	return &OperationResponse{}, nil
+}
+
+func TestCreateFn(t *testing.T) {
+	parsedEmptySchema := MustParseJSONSchema(emptySchema)
+
+	testCases := []struct {
+		desc        string
+		fn          func(context.Context, *OperationRequest) (*OperationResponse, error)
+		inputSchema *JSONSchema
+		properties  *JSONSchema
+		shouldPanic bool
+	}{
+		{
+			desc:        "OK",
+			fn:          simpleOpFn,
+			inputSchema: parsedEmptySchema,
+			properties:  parsedEmptySchema,
+		},
+		{
+			desc:        "PANIC - No input schema",
+			fn:          simpleOpFn,
+			properties:  parsedEmptySchema,
+			shouldPanic: true,
+		},
+		{
+			desc:        "PANIC - No properties schema",
+			fn:          simpleOpFn,
+			inputSchema: parsedEmptySchema,
+			shouldPanic: true,
+		},
+		{
+			desc:        "PANIC - No fn",
+			properties:  parsedEmptySchema,
+			inputSchema: parsedEmptySchema,
+			shouldPanic: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			expected := &ResourceDefinition{
+				PropertiesSchema: tc.properties,
+				create: &operation{
+					fn: tc.fn,
+					schema: schema{
+						input:  tc.inputSchema,
+						output: tc.properties,
+					},
+				},
+			}
+
+			rd := &ResourceDefinition{
+				Type:             "example",
+				PropertiesSchema: tc.properties,
+			}
+
+			if tc.shouldPanic {
+				assert.Panics(t, func() {
+					rd.CreateFn(tc.fn, tc.inputSchema)
+				})
+				return
+			}
+
+			rd.CreateFn(tc.fn, tc.inputSchema)
+			assert.NotNil(t, rd.create)
+			assert.Equal(t, expected.PropertiesSchema, rd.PropertiesSchema)
+			assert.Equal(t, expected.create.schema, rd.create.schema)
+		})
+	}
+}
+
+func TestUpdateFn(t *testing.T) {
+	parsedEmptySchema := MustParseJSONSchema(emptySchema)
+
+	testCases := []struct {
+		desc        string
+		fn          func(context.Context, *OperationRequest) (*OperationResponse, error)
+		inputSchema *JSONSchema
+		properties  *JSONSchema
+		shouldPanic bool
+	}{
+		{
+			desc:        "OK",
+			fn:          simpleOpFn,
+			inputSchema: parsedEmptySchema,
+			properties:  parsedEmptySchema,
+		},
+		{
+			desc:        "PANIC - No input schema",
+			fn:          simpleOpFn,
+			properties:  parsedEmptySchema,
+			shouldPanic: true,
+		},
+		{
+			desc:        "PANIC - No properties schema",
+			fn:          simpleOpFn,
+			inputSchema: parsedEmptySchema,
+			shouldPanic: true,
+		},
+		{
+			desc:        "PANIC - No fn",
+			properties:  parsedEmptySchema,
+			inputSchema: parsedEmptySchema,
+			shouldPanic: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			expected := &ResourceDefinition{
+				PropertiesSchema: tc.properties,
+				update: &operation{
+					fn: tc.fn,
+					schema: schema{
+						input:  tc.inputSchema,
+						output: tc.properties,
+					},
+				},
+			}
+
+			rd := &ResourceDefinition{
+				Type:             "example",
+				PropertiesSchema: tc.properties,
+			}
+
+			if tc.shouldPanic {
+				assert.Panics(t, func() {
+					rd.UpdateFn(tc.fn, tc.inputSchema)
+				})
+				return
+			}
+
+			rd.UpdateFn(tc.fn, tc.inputSchema)
+			assert.NotNil(t, rd.update)
+			assert.Equal(t, expected.PropertiesSchema, rd.PropertiesSchema)
+			assert.Equal(t, expected.update.schema, rd.update.schema)
+		})
+	}
+}
+
+func TestDeleteFn(t *testing.T) {
+	parsedEmptySchema := MustParseJSONSchema(emptySchema)
+
+	testCases := []struct {
+		desc        string
+		fn          func(context.Context, *OperationRequest) (*OperationResponse, error)
+		properties  *JSONSchema
+		shouldPanic bool
+	}{
+		{
+			desc:       "OK",
+			fn:         simpleOpFn,
+			properties: parsedEmptySchema,
+		},
+		{
+			desc:        "PANIC - No properties schema",
+			fn:          simpleOpFn,
+			shouldPanic: true,
+		},
+		{
+			desc:        "PANIC - No fn",
+			properties:  parsedEmptySchema,
+			shouldPanic: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			expected := &ResourceDefinition{
+				PropertiesSchema: tc.properties,
+				delete: &operation{
+					fn: tc.fn,
+					schema: schema{
+						input:  MustParseJSONSchema(GenericEmptySchema),
+						output: tc.properties,
+					},
+				},
+			}
+
+			rd := &ResourceDefinition{
+				Type:             "example",
+				PropertiesSchema: tc.properties,
+			}
+
+			if tc.shouldPanic {
+				assert.Panics(t, func() {
+					rd.DeleteFn(tc.fn)
+				})
+				return
+			}
+
+			rd.DeleteFn(tc.fn)
+			assert.NotNil(t, rd.delete)
+			assert.Equal(t, expected.PropertiesSchema, rd.PropertiesSchema)
+			assert.Equal(t, expected.delete.schema, rd.delete.schema)
+		})
+	}
+}
+
+func TestReadFn(t *testing.T) {
+	parsedEmptySchema := MustParseJSONSchema(emptySchema)
+
+	testCases := []struct {
+		desc        string
+		fn          func(context.Context, *OperationRequest) (*OperationResponse, error)
+		properties  *JSONSchema
+		shouldPanic bool
+	}{
+		{
+			desc:       "OK",
+			fn:         simpleOpFn,
+			properties: parsedEmptySchema,
+		},
+		{
+			desc:        "PANIC - No properties schema",
+			fn:          simpleOpFn,
+			shouldPanic: true,
+		},
+		{
+			desc:        "PANIC - No fn",
+			properties:  parsedEmptySchema,
+			shouldPanic: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			expected := &ResourceDefinition{
+				PropertiesSchema: tc.properties,
+				read: &operation{
+					fn: tc.fn,
+					schema: schema{
+						input:  MustParseJSONSchema(GenericEmptySchema),
+						output: tc.properties,
+					},
+				},
+			}
+
+			rd := &ResourceDefinition{
+				Type:             "example",
+				PropertiesSchema: tc.properties,
+			}
+
+			if tc.shouldPanic {
+				assert.Panics(t, func() {
+					rd.ReadFn(tc.fn)
+				})
+				return
+			}
+
+			rd.ReadFn(tc.fn)
+			assert.NotNil(t, rd.read)
+			assert.Equal(t, expected.PropertiesSchema, rd.PropertiesSchema)
+			assert.Equal(t, expected.read.schema, rd.read.schema)
+		})
+	}
+}
+
+func TestListFn(t *testing.T) {
+	parsedEmptySchema := MustParseJSONSchema(emptySchema)
+
+	listFn := func(_ context.Context, _ *ListRequest) (*ListResponse, error) {
+		return &ListResponse{}, nil
+	}
+
+	testCases := []struct {
+		desc        string
+		fn          func(context.Context, *ListRequest) (*ListResponse, error)
+		properties  *JSONSchema
+		shouldPanic bool
+	}{
+		{
+			desc:       "OK",
+			fn:         listFn,
+			properties: parsedEmptySchema,
+		},
+		{
+			desc:        "PANIC - No properties schema",
+			fn:          listFn,
+			shouldPanic: true,
+		},
+		{
+			desc:        "PANIC - No fn",
+			properties:  parsedEmptySchema,
+			shouldPanic: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			expected := &ResourceDefinition{
+				PropertiesSchema: tc.properties,
+				list: &listOperation{
+					fn: tc.fn,
+					schema: schema{
+						input:  MustParseJSONSchema(GenericEmptySchema),
+						output: tc.properties,
+					},
+				},
+			}
+
+			rd := &ResourceDefinition{
+				Type:             "example",
+				PropertiesSchema: tc.properties,
+			}
+
+			if tc.shouldPanic {
+				assert.Panics(t, func() {
+					rd.ListFn(tc.fn)
+				})
+				return
+			}
+
+			rd.ListFn(tc.fn)
+			assert.NotNil(t, rd.list)
+			assert.Equal(t, expected.PropertiesSchema, rd.PropertiesSchema)
+			assert.Equal(t, expected.list.schema, rd.list.schema)
+		})
+	}
+}
+
+func TestHealthcheckFn(t *testing.T) {
+	healthcheckFn := func(_ context.Context) (*HealthCheckResponse, error) {
+		return &HealthCheckResponse{}, nil
+	}
+
+	testCases := []struct {
+		desc        string
+		fn          func(context.Context) (*HealthCheckResponse, error)
+		shouldPanic bool
+	}{
+		{
+			desc: "OK",
+			fn:   healthcheckFn,
+		},
+
+		{
+			desc:        "PANIC - No fn",
+			shouldPanic: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			rd := &ResourceDefinition{
+				Type: "example",
+			}
+
+			if tc.shouldPanic {
+				assert.Panics(t, func() {
+					rd.HealthCheckFn(tc.fn)
+				})
+				return
+			}
+
+			rd.HealthCheckFn(tc.fn)
+			assert.NotNil(t, rd.healthcheck)
+		})
+	}
+}

--- a/app/resource_definition_test.go
+++ b/app/resource_definition_test.go
@@ -58,9 +58,19 @@ func TestGetResourceDefinition(t *testing.T) {
 	}
 }
 
-var simpleOpFn = func(_ context.Context, _ *OperationRequest) (*OperationResponse, error) {
-	return &OperationResponse{}, nil
-}
+var (
+	simpleOpFn = func(_ context.Context, _ *OperationRequest) (*OperationResponse, error) {
+		return &OperationResponse{}, nil
+	}
+
+	simpleHealthcheckFn = func(_ context.Context) (*HealthCheckResponse, error) {
+		return &HealthCheckResponse{}, nil
+	}
+
+	simpleListFn = func(_ context.Context, _ *ListRequest) (*ListResponse, error) {
+		return &ListResponse{}, nil
+	}
+)
 
 func TestCreateFn(t *testing.T) {
 	parsedEmptySchema := MustParseJSONSchema(emptySchema)
@@ -317,10 +327,6 @@ func TestReadFn(t *testing.T) {
 func TestListFn(t *testing.T) {
 	parsedEmptySchema := MustParseJSONSchema(emptySchema)
 
-	listFn := func(_ context.Context, _ *ListRequest) (*ListResponse, error) {
-		return &ListResponse{}, nil
-	}
-
 	testCases := []struct {
 		desc        string
 		fn          func(context.Context, *ListRequest) (*ListResponse, error)
@@ -329,12 +335,12 @@ func TestListFn(t *testing.T) {
 	}{
 		{
 			desc:       "OK",
-			fn:         listFn,
+			fn:         simpleListFn,
 			properties: parsedEmptySchema,
 		},
 		{
 			desc:        "PANIC - No properties schema",
-			fn:          listFn,
+			fn:          simpleListFn,
 			shouldPanic: true,
 		},
 		{
@@ -377,10 +383,6 @@ func TestListFn(t *testing.T) {
 }
 
 func TestHealthcheckFn(t *testing.T) {
-	healthcheckFn := func(_ context.Context) (*HealthCheckResponse, error) {
-		return &HealthCheckResponse{}, nil
-	}
-
 	testCases := []struct {
 		desc        string
 		fn          func(context.Context) (*HealthCheckResponse, error)
@@ -388,7 +390,7 @@ func TestHealthcheckFn(t *testing.T) {
 	}{
 		{
 			desc: "OK",
-			fn:   healthcheckFn,
+			fn:   simpleHealthcheckFn,
 		},
 
 		{

--- a/app/resource_test.go
+++ b/app/resource_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,7 +46,7 @@ func TestResourceFromProto(t *testing.T) {
 		},
 		{
 			desc:       "OK - nil",
-			resource:   &Resource{},
+			resource:   nil,
 			resourcepb: nil,
 		},
 	}
@@ -95,9 +96,10 @@ func TestResourceToProto(t *testing.T) {
 			},
 		},
 		{
-			desc:       "OK - nil",
+			desc:       "ERR - nil",
 			resource:   nil,
-			resourcepb: &appv1.Resource{},
+			resourcepb: nil,
+			err:        fmt.Errorf("resource is nil"),
 		},
 	}
 	for _, tc := range testCases {

--- a/app/rpc.go
+++ b/app/rpc.go
@@ -240,7 +240,7 @@ func (a *App) ListResources(ctx context.Context, req *connect.Request[appv1.List
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("list operation not supported for resource type %s", req.Msg.Resource.Type))
 	}
 
-	res, err := rd.list.handler(ctx, listRequestFromProto(req.Msg))
+	res, err := rd.list.fn(ctx, listRequestFromProto(req.Msg))
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("list resources: %w", err))
 	}

--- a/app/rpc.go
+++ b/app/rpc.go
@@ -166,7 +166,7 @@ func (a *App) ExecuteResourceOperation(ctx context.Context, req *connect.Request
 
 		// Catch any validation errors before returning the resource.
 		if err := op.schema.output.Validate(res.Resource.Properties); err != nil {
-			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("validate create output: %w", err))
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("validate update output: %w", err))
 		}
 
 		resource, err := res.Resource.toProto()
@@ -210,7 +210,7 @@ func (a *App) ExecuteResourceOperation(ctx context.Context, req *connect.Request
 
 		// Catch any validation errors before returning the resource.
 		if err := op.schema.output.Validate(res.Resource.Properties); err != nil {
-			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("validate create output: %w", err))
+			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("validate read output: %w", err))
 		}
 
 		resource, err := res.Resource.toProto()
@@ -222,7 +222,7 @@ func (a *App) ExecuteResourceOperation(ctx context.Context, req *connect.Request
 			Resource: resource,
 		}), nil
 	default:
-		return nil, fmt.Errorf("unsupported operation %s", req.Msg.Operation.String())
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("unsupported operation %s", o.String()))
 	}
 }
 

--- a/app/rpc_test.go
+++ b/app/rpc_test.go
@@ -1,0 +1,128 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appv1 "github.com/tempestdx/protobuf/gen/go/tempestdx/app/v1"
+)
+
+func TestDescribe(t *testing.T) {
+	parsedSchemaStruct, err := MustParseJSONSchema(GenericEmptySchema).toStruct()
+	require.NoError(t, err)
+
+	testCases := []struct {
+		desc   string
+		addFns []string
+		want   *connect.Response[appv1.DescribeResponse]
+		err    error
+	}{
+		{
+			desc:   "OK - Fully Loaded",
+			addFns: []string{"create", "read", "update", "delete", "list", "healthcheck"},
+			want: connect.NewResponse(&appv1.DescribeResponse{
+				ResourceDefinitions: []*appv1.ResourceDefinition{
+					{
+						Type:             "example",
+						DisplayName:      "Example",
+						Description:      "An example resource",
+						PropertiesSchema: parsedSchemaStruct,
+						LifecycleStage:   appv1.LifecycleStage_LIFECYCLE_STAGE_OPERATE,
+						Links: []*appv1.Link{
+							{
+								Url:   "http://example.com",
+								Title: "Example",
+								Type:  appv1.LinkType_LINK_TYPE_DOCUMENTATION,
+							},
+						},
+						InstructionsMarkdown: "This is an example resource",
+						ListSupported:        true,
+						HealthcheckSupported: true,
+						ReadSupported:        true,
+						CreateSupported:      true,
+						UpdateSupported:      true,
+						DeleteSupported:      true,
+						CreateInputSchema:    parsedSchemaStruct,
+						UpdateInputSchema:    parsedSchemaStruct,
+						Actions: []*appv1.ActionDefinition{
+							{
+								Name:         "do_something",
+								DisplayName:  "Do Something",
+								Description:  "Do something with the resource",
+								InputSchema:  parsedSchemaStruct,
+								OutputSchema: parsedSchemaStruct,
+							},
+						},
+					},
+				},
+			}),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			app := &App{
+				resourceDefinitions: []ResourceDefinition{generateRD(tc.addFns)},
+			}
+
+			res, err := app.Describe(context.Background(), connect.NewRequest(&appv1.DescribeRequest{}))
+			if tc.err != nil {
+				assert.EqualError(t, err, tc.err.Error())
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, res)
+		})
+	}
+}
+
+func generateRD(fns []string) ResourceDefinition {
+	parsedSchema := MustParseJSONSchema(GenericEmptySchema)
+
+	rd := ResourceDefinition{
+		Type:             "example",
+		DisplayName:      "Example",
+		Description:      "An example resource",
+		PropertiesSchema: parsedSchema,
+		LifecycleStage:   LifecycleStageOperate,
+		Links: []Link{
+			{
+				URL:   "http://example.com",
+				Title: "Example",
+				Type:  LinkTypeDocumentation,
+			},
+		},
+		InstructionsMarkdown: "This is an example resource",
+		actions: []ActionDefinition{
+			{
+				Name:         "do_something",
+				DisplayName:  "Do Something",
+				Description:  "Do something with the resource",
+				InputSchema:  parsedSchema,
+				OutputSchema: parsedSchema,
+			},
+		},
+	}
+
+	for _, fn := range fns {
+		switch fn {
+		case "create":
+			rd.CreateFn(simpleOpFn, parsedSchema)
+		case "update":
+			rd.UpdateFn(simpleOpFn, parsedSchema)
+		case "read":
+			rd.ReadFn(simpleOpFn)
+		case "delete":
+			rd.DeleteFn(simpleOpFn)
+		case "list":
+			rd.ListFn(simpleListFn)
+		case "healthcheck":
+			rd.HealthCheckFn(simpleHealthcheckFn)
+		}
+	}
+
+	return rd
+}

--- a/app/rpc_test.go
+++ b/app/rpc_test.go
@@ -257,6 +257,10 @@ func TestExecuteResourceOperation_Create(t *testing.T) {
 
 			if tc.enableCreate {
 				rd.CreateFn(func(_ context.Context, req *OperationRequest) (*OperationResponse, error) {
+					if tc.createErr != nil {
+						return nil, tc.createErr
+					}
+
 					return &OperationResponse{
 						Resource: &Resource{
 							ExternalID:  "example-1",
@@ -274,7 +278,7 @@ func TestExecuteResourceOperation_Create(t *testing.T) {
 								},
 							},
 						},
-					}, tc.createErr
+					}, nil
 				}, tc.inputSchema)
 			}
 
@@ -420,6 +424,10 @@ func TestExecuteResourceOperation_Update(t *testing.T) {
 
 			if tc.enableUpdate {
 				rd.UpdateFn(func(_ context.Context, req *OperationRequest) (*OperationResponse, error) {
+					if tc.updateErr != nil {
+						return nil, tc.updateErr
+					}
+
 					return &OperationResponse{
 						Resource: &Resource{
 							ExternalID:  "example-1",
@@ -437,7 +445,7 @@ func TestExecuteResourceOperation_Update(t *testing.T) {
 								},
 							},
 						},
-					}, tc.updateErr
+					}, nil
 				}, tc.inputSchema)
 			}
 
@@ -478,9 +486,6 @@ func TestExecuteResourceOperation_Delete(t *testing.T) {
 					Type:       "example",
 					ExternalId: "example-1",
 				},
-				Input: mustNewStruct(map[string]any{
-					"key": "value",
-				}),
 				Operation: appv1.ResourceOperation_RESOURCE_OPERATION_DELETE,
 			},
 			want: connect.NewResponse(&appv1.ExecuteResourceOperationResponse{
@@ -509,12 +514,20 @@ func TestExecuteResourceOperation_Delete(t *testing.T) {
 					Type:       "example",
 					ExternalId: "example-1",
 				},
-				Input: mustNewStruct(map[string]any{
-					"key": "value",
-				}),
 				Operation: appv1.ResourceOperation_RESOURCE_OPERATION_DELETE,
 			},
 			err: fmt.Errorf("invalid_argument: operation RESOURCE_OPERATION_DELETE not supported for resource type example"),
+		},
+		{
+			desc:         "ERR - No External ID",
+			enableDelete: true,
+			req: &appv1.ExecuteResourceOperationRequest{
+				Resource: &appv1.Resource{
+					Type: "example",
+				},
+				Operation: appv1.ResourceOperation_RESOURCE_OPERATION_DELETE,
+			},
+			err: fmt.Errorf("invalid_argument: external ID is required for delete operation"),
 		},
 		{
 			desc:         "ERR - Delete Error",
@@ -524,9 +537,6 @@ func TestExecuteResourceOperation_Delete(t *testing.T) {
 					Type:       "example",
 					ExternalId: "example-1",
 				},
-				Input: mustNewStruct(map[string]any{
-					"key": "value",
-				}),
 				Operation: appv1.ResourceOperation_RESOURCE_OPERATION_DELETE,
 			},
 			deleteErr: fmt.Errorf("delete error"),
@@ -538,6 +548,10 @@ func TestExecuteResourceOperation_Delete(t *testing.T) {
 			rd := generateRD(nil)
 			if tc.enableDelete {
 				rd.DeleteFn(func(_ context.Context, req *OperationRequest) (*OperationResponse, error) {
+					if tc.deleteErr != nil {
+						return nil, tc.deleteErr
+					}
+
 					return &OperationResponse{
 						Resource: &Resource{
 							ExternalID:  "example-1",
@@ -555,7 +569,7 @@ func TestExecuteResourceOperation_Delete(t *testing.T) {
 								},
 							},
 						},
-					}, tc.deleteErr
+					}, nil
 				})
 			}
 
@@ -595,9 +609,6 @@ func TestExecuteResourceOperation_Read(t *testing.T) {
 					Type:       "example",
 					ExternalId: "example-1",
 				},
-				Input: mustNewStruct(map[string]any{
-					"key": "value",
-				}),
 				Operation: appv1.ResourceOperation_RESOURCE_OPERATION_READ,
 			},
 			want: connect.NewResponse(&appv1.ExecuteResourceOperationResponse{
@@ -626,12 +637,20 @@ func TestExecuteResourceOperation_Read(t *testing.T) {
 					Type:       "example",
 					ExternalId: "example-1",
 				},
-				Input: mustNewStruct(map[string]any{
-					"key": "value",
-				}),
 				Operation: appv1.ResourceOperation_RESOURCE_OPERATION_READ,
 			},
 			err: fmt.Errorf("invalid_argument: operation RESOURCE_OPERATION_READ not supported for resource type example"),
+		},
+		{
+			desc:       "ERR - No External ID",
+			enableRead: true,
+			req: &appv1.ExecuteResourceOperationRequest{
+				Resource: &appv1.Resource{
+					Type: "example",
+				},
+				Operation: appv1.ResourceOperation_RESOURCE_OPERATION_READ,
+			},
+			err: fmt.Errorf("invalid_argument: external ID is required for read operation"),
 		},
 		{
 			desc:       "ERR - Read Error",
@@ -641,9 +660,6 @@ func TestExecuteResourceOperation_Read(t *testing.T) {
 					Type:       "example",
 					ExternalId: "example-1",
 				},
-				Input: mustNewStruct(map[string]any{
-					"key": "value",
-				}),
 				Operation: appv1.ResourceOperation_RESOURCE_OPERATION_READ,
 			},
 			readErr: fmt.Errorf("read error"),
@@ -658,9 +674,6 @@ func TestExecuteResourceOperation_Read(t *testing.T) {
 					Type:       "example",
 					ExternalId: "example-1",
 				},
-				Input: mustNewStruct(map[string]any{
-					"key": "value",
-				}),
 				Operation: appv1.ResourceOperation_RESOURCE_OPERATION_READ,
 			},
 			err: fmt.Errorf("internal: validate read output: jsonschema: '' does not validate"),
@@ -675,6 +688,10 @@ func TestExecuteResourceOperation_Read(t *testing.T) {
 
 			if tc.enableRead {
 				rd.ReadFn(func(_ context.Context, req *OperationRequest) (*OperationResponse, error) {
+					if tc.readErr != nil {
+						return nil, tc.readErr
+					}
+
 					return &OperationResponse{
 						Resource: &Resource{
 							ExternalID:  "example-1",
@@ -692,7 +709,7 @@ func TestExecuteResourceOperation_Read(t *testing.T) {
 								},
 							},
 						},
-					}, tc.readErr
+					}, nil
 				})
 			}
 
@@ -701,6 +718,202 @@ func TestExecuteResourceOperation_Read(t *testing.T) {
 			}
 
 			res, err := app.ExecuteResourceOperation(context.Background(), connect.NewRequest(tc.req))
+			if tc.err != nil {
+				if tc.desc == "ERR - Invalid Output" {
+					assert.ErrorContains(t, err, tc.err.Error())
+				} else {
+					assert.EqualError(t, err, tc.err.Error())
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, res)
+		})
+	}
+}
+
+func TestListResources(t *testing.T) {
+	parsedSimpleSchema := MustParseJSONSchema(simpleSchema)
+
+	testCases := []struct {
+		desc             string
+		numResources     int
+		want             *connect.Response[appv1.ListResourcesResponse]
+		req              *appv1.ListResourcesRequest
+		propertiesSchema *JSONSchema
+		enableList       bool
+		listErr          error
+		err              error
+	}{
+		{
+			desc:         "OK - Single Resource",
+			enableList:   true,
+			numResources: 1,
+			req: &appv1.ListResourcesRequest{
+				Resource: &appv1.Resource{
+					Type: "example",
+				},
+				Next: "1",
+			},
+			want: connect.NewResponse(&appv1.ListResourcesResponse{
+				Resources: []*appv1.Resource{
+					{
+						Type:        "example",
+						ExternalId:  "example-1",
+						DisplayName: "Example",
+						Properties: mustNewStruct(map[string]any{
+							"key":       "value",
+							"other_key": "other_value",
+						}),
+						Links: []*appv1.Link{
+							{
+								Url:   "http://example.com",
+								Title: "Example",
+								Type:  appv1.LinkType_LINK_TYPE_DOCUMENTATION,
+							},
+						},
+					},
+				},
+			}),
+		},
+		{
+			desc:         "OK - Multiple Resources",
+			enableList:   true,
+			numResources: 2,
+			req: &appv1.ListResourcesRequest{
+				Resource: &appv1.Resource{
+					Type: "example",
+				},
+				Next: "1",
+			},
+			want: connect.NewResponse(&appv1.ListResourcesResponse{
+				Resources: []*appv1.Resource{
+					{
+						Type:        "example",
+						ExternalId:  "example-1",
+						DisplayName: "Example",
+						Properties: mustNewStruct(map[string]any{
+							"key":       "value",
+							"other_key": "other_value",
+						}),
+						Links: []*appv1.Link{
+							{
+								Url:   "http://example.com",
+								Title: "Example",
+								Type:  appv1.LinkType_LINK_TYPE_DOCUMENTATION,
+							},
+						},
+					},
+					{
+						Type:        "example",
+						ExternalId:  "example-2",
+						DisplayName: "Example",
+						Properties: mustNewStruct(map[string]any{
+							"key":       "value",
+							"other_key": "other_value",
+						}),
+						Links: []*appv1.Link{
+							{
+								Url:   "http://example.com",
+								Title: "Example",
+								Type:  appv1.LinkType_LINK_TYPE_DOCUMENTATION,
+							},
+						},
+					},
+				},
+			}),
+		},
+		{
+			desc: "ERR - List Disabled",
+			req: &appv1.ListResourcesRequest{
+				Resource: &appv1.Resource{
+					Type: "example",
+				},
+				Next: "1",
+			},
+			err: fmt.Errorf("invalid_argument: list operation not supported for resource type example"),
+		},
+		{
+			desc:       "ERR - List Error",
+			enableList: true,
+			req: &appv1.ListResourcesRequest{
+				Resource: &appv1.Resource{
+					Type: "example",
+				},
+				Next: "1",
+			},
+			listErr: fmt.Errorf("list error"),
+			err:     fmt.Errorf("internal: list resources: list error"),
+		},
+		{
+			desc:             "ERR - Invalid Output",
+			enableList:       true,
+			numResources:     2,
+			propertiesSchema: parsedSimpleSchema,
+			req: &appv1.ListResourcesRequest{
+				Resource: &appv1.Resource{
+					Type: "example",
+				},
+				Next: "1",
+			},
+			err: fmt.Errorf("internal: validate resource properties: jsonschema: '' does not validate"),
+		},
+		{
+			desc: "ERR - Resource Missing",
+			req: &appv1.ListResourcesRequest{
+				Resource: &appv1.Resource{
+					Type: "not_found",
+				},
+				Next: "1",
+			},
+			err: fmt.Errorf("not_found: resource type not_found not found"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			rd := generateRD(nil)
+			if tc.propertiesSchema != nil {
+				rd.PropertiesSchema = tc.propertiesSchema
+			}
+
+			if tc.enableList {
+				rd.ListFn(func(_ context.Context, req *ListRequest) (*ListResponse, error) {
+					if tc.listErr != nil {
+						return nil, tc.listErr
+					}
+
+					var resources []*Resource
+					for i := 0; i < tc.numResources; i++ {
+						resources = append(resources, &Resource{
+							ExternalID:  fmt.Sprintf("example-%d", i+1),
+							DisplayName: "Example",
+							Type:        "example",
+							Properties: map[string]any{
+								"key":       "value",
+								"other_key": "other_value",
+							},
+							Links: []*Link{
+								{
+									URL:   "http://example.com",
+									Title: "Example",
+									Type:  LinkTypeDocumentation,
+								},
+							},
+						})
+					}
+
+					return &ListResponse{
+						Resources: resources,
+					}, nil
+				})
+			}
+
+			app := &App{
+				resourceDefinitions: []ResourceDefinition{rd},
+			}
+
+			res, err := app.ListResources(context.Background(), connect.NewRequest(tc.req))
 			if tc.err != nil {
 				if tc.desc == "ERR - Invalid Output" {
 					assert.ErrorContains(t, err, tc.err.Error())


### PR DESCRIPTION
## Contents

1. Prefer returning `nil` when the input is `nil` for the various toProto and fromProto functions.
2. Add test coverage across the SDK.
3. Check for nil input functions to Delete, Read, List, and Healthcheck.
4. DeleteFn will now use the resource properties schema.
5. Read, Update, Delete will error if the external ID is missing.