### PR TITLE
add a validateJSONSchema function

### DIFF
--- a/app/json_schema_test.go
+++ b/app/json_schema_test.go
@@ -247,3 +247,69 @@ func TestInjectDefaults(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateJSONSchema(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		schema   []byte
+		expected error
+	}{
+		{
+			desc: "Valid schema",
+			schema: []byte(`{
+                "properties": {
+                    "property1": {
+                        "type": "string"
+                    },
+                    "property2": {
+                        "type": "number"
+                    }
+                }
+            }`),
+			expected: nil,
+		},
+		{
+			desc: "Invalid schema - property of type object",
+			schema: []byte(`{
+                "properties": {
+                    "property1": {
+                        "type": "object"
+                    }
+                }
+            }`),
+			expected: errors.New("properties should not be of type 'object'"),
+		},
+		{
+			desc: "Invalid schema - property with $ref",
+			schema: []byte(`{
+                "properties": {
+                    "property1": {
+                        "$ref": "#/definitions/someDefinition"
+                    }
+                }
+            }`),
+			expected: errors.New("properties should not be references"),
+		},
+		{
+			desc: "Invalid schema - properties is not an object",
+			schema: []byte(`{
+                "properties": "not an object"
+            }`),
+			expected: errors.New("properties should be an object"),
+		},
+		{
+			desc: "Valid schema - no properties",
+			schema: []byte(`{
+                "title": "Example Schema"
+            }`),
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := validateJSONSchema(tc.schema)
+			assert.Equal(t, tc.expected, err)
+		})
+	}
+}

--- a/app/json_schema_test.go
+++ b/app/json_schema_test.go
@@ -277,7 +277,7 @@ func TestValidateJSONSchema(t *testing.T) {
                     }
                 }
             }`),
-			expected: errors.New("properties should not be of type 'object'"),
+			expected: errPropertiesShouldNotBeObject,
 		},
 		{
 			desc: "Invalid schema - property with $ref",
@@ -288,14 +288,28 @@ func TestValidateJSONSchema(t *testing.T) {
                     }
                 }
             }`),
-			expected: errors.New("properties should not be references"),
+			expected: errPropertiesShouldNotBeReferences,
 		},
 		{
 			desc: "Invalid schema - properties is not an object",
 			schema: []byte(`{
                 "properties": "not an object"
             }`),
-			expected: errors.New("properties should be an object"),
+			expected: errPropertiesShouldBeObject,
+		},
+		{
+			desc: "Invalid schema - property is an array of objects",
+			schema: []byte(`{
+                "properties": {
+                    "property1": {
+                        "type": "array",
+                        "items": {
+                            "type": "object"
+                        }
+                    }
+                }
+            }`),
+			expected: errPropertiesShouldNotBeArrayOfObjects,
 		},
 		{
 			desc: "Valid schema - no properties",

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/stretchr/testify v1.9.0
 	github.com/tempestdx/protobuf v0.1.1
+	github.com/tidwall/gjson v1.18.0
 	golang.org/x/tools v0.27.0
 	google.golang.org/protobuf v1.35.2
 )
@@ -14,6 +15,8 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	golang.org/x/mod v0.22.0 // indirect
 	golang.org/x/sync v0.9.0 // indirect
 	golang.org/x/text v0.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,12 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tempestdx/protobuf v0.1.1 h1:lXr/c66pounQn7pIbN+A2eA+3z9tN7nmVjbRurNAaNw=
 github.com/tempestdx/protobuf v0.1.1/go.mod h1:9CmOJ2y+f9Hjo6XwXscDMb+RuYn8MnPXRtPSkt/yG1g=
+github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
+github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 golang.org/x/mod v0.22.0 h1:D4nJWe9zXqHOmWqj4VMOJhvzj7bEZg4wEYa759z1pH4=
 golang.org/x/mod v0.22.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/net v0.31.0 h1:68CPQngjLL0r2AlUKiSxtQFKvzRVbnzLwMUn5SzcLHo=


### PR DESCRIPTION
## Contents

1. Adds a new step in JSON Schema parsing which will reject schemas based on Tempest product constraints. To start, we'll block any properties that hold a "$ref" to another field, and any properties that are "objects". These constraints are subject to change in the future.

## Testing

1. Added new test cases for the `validateJSONSchema` function.